### PR TITLE
Add imports for User model to routes where needed

### DIFF
--- a/app/api/prompt/[id]/route.js
+++ b/app/api/prompt/[id]/route.js
@@ -1,4 +1,6 @@
 import Prompt from "@models/prompt";
+import User from "@models/user";
+
 import { connectToDB } from "@utils/database";
 
 export const GET = async (request, { params }) => {

--- a/app/api/prompt/route.js
+++ b/app/api/prompt/route.js
@@ -1,4 +1,6 @@
 import Prompt from "@models/prompt";
+import User from "@models/user";
+
 import { connectToDB } from "@utils/database";
 
 export const GET = async (request) => {

--- a/app/api/users/[id]/posts/route.js
+++ b/app/api/users/[id]/posts/route.js
@@ -1,4 +1,6 @@
 import Prompt from "@models/prompt";
+import User from "@models/user";
+
 import { connectToDB } from "@utils/database";
 
 export const GET = async (request, { params }) => {


### PR DESCRIPTION
If you try to deploy the project using Vercel - you will be getting errors on first load when fetching data of prompts. I've been seeing this errors on Feed and Profile components on first load of the page (When serverless functions are on cold boot) or after some delay when the web site was inactive (about after 15-30 min). 
The server error message is `MissingSchemaError: Schema hasn't been registered for model "User". Use mongoose.model(name, schema)`.
To fix the problem you need to add Imports of the User model where you are using .populate("creator") method.

What is interesting about this issue - is that you're not getting this errors in local development runs or even after site was active after some reloads.

The material I was using to fix the problem: https://dev.to/janetthedev/using-mongooses-populate-in-nextjs-4jof