### PR TITLE
update next.config.js for next14

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,19 +1,23 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
-    appDir: true,
     serverComponentsExternalPackages: ["mongoose"],
   },
   images: {
-    domains: ['lh3.googleusercontent.com'],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+      },
+    ],
   },
   webpack(config) {
     config.experiments = {
       ...config.experiments,
       topLevelAwait: true,
-    }
-    return config
-  }
-}
+    };
+    return config;
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;


### PR DESCRIPTION
Updated syntax of next.config.js to work with next.js v14.

- Removed experimental appDir as no longer experimental
- changed image dir syntax

*This shouldn't be merged because the repo isn't using next.js v14, but helpful for following tutorial*